### PR TITLE
Clean up Fusion state modules

### DIFF
--- a/src/shared/FusionUI/organisms/PlayerHUD/ActionBar.ts
+++ b/src/shared/FusionUI/organisms/PlayerHUD/ActionBar.ts
@@ -7,10 +7,8 @@
  * @description Container for the player's ability bar on the HUD.
  */
 
-import Fusion from "@rbxts/fusion";
+import { Value } from "@rbxts/fusion";
 import { BaseFrame, Lists, SlotButton, SlotButtonProps, IconAssets } from "../../atoms";
-
-const { Value } = Fusion;
 export interface ActionBarProps {
 	SlotCount?: number;
 }

--- a/src/shared/FusionUI/organisms/PlayerHUD/MenuBar.ts
+++ b/src/shared/FusionUI/organisms/PlayerHUD/MenuBar.ts
@@ -7,7 +7,6 @@
  * @description Row of buttons for opening HUD panels.
  */
 
-import Fusion, { Value } from "@rbxts/fusion";
 import { BaseFrame, IconButton, IconAssets, Lists } from "../../atoms";
 import { MenuButton } from "shared/FusionUI/molecules/MenuButton";
 
@@ -17,12 +16,6 @@ const MenuButtonSize = UDim2.fromOffset(50, 50);
 interface MenuBarProps {
 	Size: UDim2;
 	Position: UDim2;
-	OnMenuButtonClick?: (buttonName: string) => void;
-}
-
-function OnMenuButtonClick(buttonName: string) {
-	print(`Menu button ${buttonName} clicked`);
-	// Handle button click logic here, e.g. open corresponding panel
 }
 
 /** Horizontal menu with common panel buttons. */

--- a/src/shared/FusionUI/states/EquipmentState.ts
+++ b/src/shared/FusionUI/states/EquipmentState.ts
@@ -1,6 +1,18 @@
-import Fusion, { Computed } from "@rbxts/fusion";
-import { Players } from "@rbxts/services";
-const LocalPlayer = Players.LocalPlayer;
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        EquipmentState.ts
+ * @module      EquipmentState
+ * @layer       State
+ * @description Placeholder for inventory and gear state.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ */
+
+import Fusion from "@rbxts/fusion";
 
 export class EquipmentState {
 	private static Initialized() {}

--- a/src/shared/FusionUI/states/Helpers/FusionResource.ts
+++ b/src/shared/FusionUI/states/Helpers/FusionResource.ts
@@ -1,3 +1,17 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        FusionResource.ts
+ * @module      FusionResource
+ * @layer       State
+ * @description Helper factory for consumable resource slices.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ */
+
 import { Value, Computed } from "@rbxts/fusion";
 
 /** All data the UI needs for one consumable resource */

--- a/src/shared/FusionUI/states/PlayerInfo.ts
+++ b/src/shared/FusionUI/states/PlayerInfo.ts
@@ -1,6 +1,20 @@
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        PlayerInfo.ts
+ * @module      PlayerInfoState
+ * @layer       State
+ * @description Reactive state slice containing basic player info used across the UI.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ */
+
 import Fusion from "@rbxts/fusion";
 
-const { Value, Computed } = Fusion;
+const { Value } = Fusion;
 
 export class PlayerInfoState {
 	// Player's name

--- a/src/shared/FusionUI/states/PlayerResources.ts
+++ b/src/shared/FusionUI/states/PlayerResources.ts
@@ -1,7 +1,19 @@
-import Fusion, { Computed } from "@rbxts/fusion";
-import { Players } from "@rbxts/services";
+/// <reference types="@rbxts/types" />
+
+/**
+ * @file        PlayerResources.ts
+ * @module      PlayerResources
+ * @layer       State
+ * @description Centralised resource slices used across the HUD.
+ *
+ * ╭───────────────────────────────╮
+ * │  Soul Steel · Coding Guide    │
+ * │  Fusion v4 · Strict TS · ECS  │
+ * ╰───────────────────────────────╯
+ */
+
+import Fusion from "@rbxts/fusion";
 import { createFusionResource } from "./Helpers/FusionResource";
-const LocalPlayer = Players.LocalPlayer;
 
 export class PlayerResources {
 	public static HealthResource = createFusionResource(1, 100, new Color3(0.8, 0.1, 0.1));


### PR DESCRIPTION
## Summary
- add missing TSDoc headers for several Fusion state files
- strip unused imports from ActionBar and MenuBar
- simplify Fusion imports for ActionBar
- document Equipment, PlayerInfo and PlayerResources state
- tidy helper FusionResource doc block

## Testing
- `npm run lint`
- `npx prettier -w src/shared/FusionUI/states/PlayerInfo.ts src/shared/FusionUI/states/PlayerResources.ts src/shared/FusionUI/states/EquipmentState.ts src/shared/FusionUI/states/Helpers/FusionResource.ts src/shared/FusionUI/organisms/PlayerHUD/ActionBar.ts src/shared/FusionUI/organisms/PlayerHUD/MenuBar.ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683c44f56ea88327a4a7a51cde3aa40e